### PR TITLE
Refactor mocks, protocols, and tests to setup and pass CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target
+.git

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  ci:
+      runs-on: self-hosted
+      steps:
+          - name: Checkout Code
+            uses: actions/checkout@v2
+          - name: Get the version
+            id: vars
+            run: echo ::set-output name=tag::$(uuidgen)
+          - name: Build and Test
+            run: |
+              docker build -t protocol-host-rs:${{steps.vars.outputs.tag}} .
+              docker rmi protocol-host-rs:${{steps.vars.outputs.tag}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,8 @@
 on:
   push:
-    branches: [ $default-branch ]
+    branches: [ master ]
   pull_request:
-    branches: [ $default-branch ]
+    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,15 +7,15 @@
         {
             "type": "lldb",
             "request": "launch",
-            "name": "Debug executable 'vr_actuators_cli'",
+            "name": "Debug executable 'protocol_host_rs'",
             "cargo": {
                 "args": [
                     "build",
-                    "--bin=vr_actuators_cli",
-                    "--package=vr_actuators_cli"
+                    "--bin=protocol_host_rs",
+                    "--package=protocol_host_rs"
                 ],
                 "filter": {
-                    "name": "vr_actuators_cli",
+                    "name": "protocol_host_rs",
                     "kind": "bin"
                 }
             },
@@ -28,16 +28,16 @@
         {
             "type": "lldb",
             "request": "launch",
-            "name": "Debug unit tests in executable 'vr_actuators_cli'",
+            "name": "Debug unit tests in executable 'protocol_host_rs'",
             "cargo": {
                 "args": [
                     "test",
                     "--no-run",
-                    "--bin=vr_actuators_cli",
-                    "--package=vr_actuators_cli"
+                    "--bin=protocol_host_rs",
+                    "--package=protocol_host_rs"
                 ],
                 "filter": {
-                    "name": "vr_actuators_cli",
+                    "name": "protocol_host_rs",
                     "kind": "bin"
                 }
             },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -32,7 +32,7 @@
 			"args": [
 				"test",
 				"--package",
-				"vr_actuators_cli",
+				"protocol_host_rs",
 				"--test",
 				"tests",
 				"--",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "protocol_host_rs"
+version = "0.2.0"
+dependencies = [
+ "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libusb 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "owning_ref 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "simple_logger 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zmq 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "simple_logger"
-version = "1.6.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -367,24 +385,6 @@ dependencies = [
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "vr_actuators_cli"
-version = "0.1.0"
-dependencies = [
- "byteorder 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libusb 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "owning_ref 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "simple_logger 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "zmq 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "wasi"
@@ -468,7 +468,7 @@ dependencies = [
 "checksum serde 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
 "checksum serde_derive 1.0.114 (registry+https://github.com/rust-lang/crates.io-index)" = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 "checksum serde_json 1.0.56 (registry+https://github.com/rust-lang/crates.io-index)" = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
-"checksum simple_logger 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fea0c4611f32f4c2bac73754f22dca1f57e6c1945e0590dae4e5f2a077b92367"
+"checksum simple_logger 1.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cd57f17c093ead1d4a1499dc9acaafdd71240908d64775465543b8d9a9f1d198"
 "checksum smallvec 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,29 @@
 [package]
-name = "vr_actuators_cli"
-version = "0.1.0"
+name = "protocol_host_rs"
+version = "0.2.0"
 authors = ["Jacob Trueb <jtrueb@northwestern.edu>"]
 edition = "2018"
+
+[lib]
+name = "protocol_host_lib"
+path = "src/lib.rs"
+
+[[bin]]
+name = "protocol_host_cli"
+path = "src/main.rs"
+
+[features]
+default = ["mock"]
+
+# Allow always successful mock connections
+mock = []
+# Allow connections over usb via libusb
+usb = [ "libusb" ]
+# Allow connections over ethernet via tcp/ip
+ethernet = []
+
+# Allow the Haptic v0 protocol over the whatever connection is configured
+haptic_v0 = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -10,12 +31,12 @@ edition = "2018"
 byteorder = "1.3.4"
 clap = "2.33.1"
 hex = "0.4.2"
-libusb = "0.3"
+libusb = { version = "0.3", optional = true }
 log = "0.4.8"
 owning_ref = "0.4.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-simple_logger = "1.6.0"
+simple_logger = "1.11.0"
 smallvec = "1.4.1"
 uuid = { version = "0.8", features = ["v4"] }
 zmq = "0.9"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN date
+
+RUN apt update && \
+    apt install -y apt-utils gcc build-essential glances htop vim tree curl \
+        pkg-config \
+        libzmq3-dev \
+        libusb-1.0-0-dev && \
+    apt clean
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /home/rustup.sh && \
+    chmod +x /home/rustup.sh && \
+    /home/rustup.sh -y && \
+    . $HOME/.cargo/env && \
+    echo ". $HOME/.cargo/env" >> $HOME/.shrc
+
+RUN mkdir -p /home/app && \
+    echo "RUST_LOG=trace" >> /home/app/.env
+
+COPY src /home/app/src/
+COPY tests /home/app/tests/
+COPY commands /home/app/commands/
+COPY Cargo.toml Cargo.lock /home/app/
+
+ARG CARGO_FLAGS
+RUN cd /home/app && . $HOME/.shrc && \
+    cargo build ${CARGO_FLAGS} && \
+    cargo test ${CARGO_FLAGS}
+
+RUN cd /home/app && . $HOME/.shrc && \
+    cargo check && \
+    cargo check --features "usb" && \
+    cargo check --features "ethernet" && \
+    cargo check --features "haptic_v0 usb" && \
+    cargo check --features "haptic_v0 ethernet" && \
+    cargo check --features "haptic_v0 ethernet" --release && \
+    cargo check --release
+
+RUN date

--- a/README.md
+++ b/README.md
@@ -10,6 +10,29 @@ This repo contains a Rust CLI for manipulating VR Actuators. This includes a dae
 
 ## Running
 
+### Feature flags
+
+The connection and protocol in use is set via cargo feature flags.
+
+The following connection types are available:
+* usb
+* ethernet
+* mock (default)
+
+The following protocol types are available:
+* haptic_v0
+* mock (default)
+
+An example invocation for a Feig Host for a Haptic V0 device might use:
+* Start an actual server: `cargo run --features "ethernet haptic_v0" -- -vvv start ... rest of the args ...`
+    * Runs over EthernetConnection and HapticV0Protocol
+* Build against feature configurations: `cargo build --features "usb"`
+    * Build requires libusb etc, and would mock protocol usage of an actual usb connection
+* Test against feature configurations: `cargo test --features "usb haptic_v0"`
+    * Build and run integration tests of HapticV0Protocol over an actual UsbConnection
+* Some won't work together: `cargo test --features "mock haptic_v0"`
+    * Responses from mock or failed connections won't work with protocols that expect pre/post conditions dependent on the connection type implementation
+
 ### Antenna Host
 
 The Feig Reader should be attached by USB to the host where we `start` a server. The command to start the antenna host may look like:
@@ -64,16 +87,16 @@ cargo run --release -- -vv start --routine rrbroker -1 tcp://0.0.0.0:6000 -2 tcp
 #### CLI Help
 View the help documents like top command help shows subcommands
 ```
-jwtrueb@dhcp-10-101-176-87 vr_actuators_cli % cargo run -- --help
-   Compiling vr_actuators_cli v0.1.0 (/Users/jwtrueb/Desktop/workspace/vr-actuators/vr_actuators_cli)
+jwtrueb@dhcp-10-101-176-87 protocol_host_rs % cargo run -- --help
+   Compiling protocol_host_rs v0.1.0 (/Users/jwtrueb/Desktop/workspace/vr-actuators/protocol_host_rs)
     Finished dev [unoptimized + debuginfo] target(s) in 4.09s
-     Running `target/debug/vr_actuators_cli --help`
+     Running `target/debug/protocol_host_rs --help`
 VR Actuators v0.1
 Jacob Trueb <jtrueb@northwestern.edu
 Manipulate VR Actuator Blocks
 
 USAGE:
-    vr_actuators_cli [FLAGS] [SUBCOMMAND]
+    protocol_host_rs [FLAGS] [SUBCOMMAND]
 
 FLAGS:
     -h, --help       Prints help information
@@ -88,14 +111,14 @@ SUBCOMMANDS:
 
 subcommand help
 ```
-jwtrueb@dhcp-10-101-176-87 vr_actuators_cli % cargo run -- start --help
+jwtrueb@dhcp-10-101-176-87 protocol_host_rs % cargo run -- start --help
     Finished dev [unoptimized + debuginfo] target(s) in 0.04s
-     Running `target/debug/vr_actuators_cli start --help`
-vr_actuators_cli-start
+     Running `target/debug/protocol_host_rs start --help`
+protocol_host_rs-start
 Starts the service that manages the connection to the VR Actuators
 
 USAGE:
-    vr_actuators_cli start [OPTIONS]
+    protocol_host_rs start [OPTIONS]
 
 FLAGS:
         --help       Prints help information
@@ -110,20 +133,20 @@ OPTIONS:
 
 #### Example Server Output
 ```
-jwtrueb@dhcp-10-101-176-87 vr_actuators_cli % cargo run --release -- -vv start --protocol tcp --hostname ubuntu20 --port 6001
+jwtrueb@dhcp-10-101-176-87 protocol_host_rs % cargo run --release -- -vv start --protocol tcp --hostname ubuntu20 --port 6001
     Finished release [optimized] target(s) in 0.04s
-     Running `target/release/vr_actuators_cli -vv start --protocol tcp --hostname ubuntu20 --port 6001`
-2020-09-02 15:12:17,703 DEBUG [vr_actuators_cli] Found level_filter: DEBUG
-2020-09-02 15:12:17,704 INFO  [vr_actuators_cli] Starting up ...
-2020-09-02 15:12:17,704 INFO  [vr_actuators_cli::network] Connected to tcp://ubuntu20:6001
-2020-09-02 15:12:17,712 DEBUG [vr_actuators_cli::network::vrp] Found Obid/Feig USB Device || Bus 020 Device 009 ID 2737 : 2
-2020-09-02 15:12:17,782 DEBUG [vr_actuators_cli::network::vrp] Claiming interface: 0
-2020-09-02 15:12:17,784 DEBUG [vr_actuators_cli::network::vrp] Claiming interface: 1
-2020-09-02 15:12:17,784 INFO  [vr_actuators_cli::network] Beginning serve() loop ...
-2020-09-02 15:12:22,733 INFO  [vr_actuators_cli::network] Received SetRadioFreqPower command for power_level 0.
-2020-09-02 15:12:22,740 DEBUG [vr_actuators_cli::network::vrp] Sent Serial Command with 44 bytes: 02002cff8b020101011e0003000884800000000000000000008100000000000000000000000000000000a7e6
-2020-09-02 15:12:22,760 DEBUG [vr_actuators_cli::network::vrp] Received Response to Serial Command with 8 bytes: 020008008b009a8d
-2020-09-02 15:12:22,760 INFO  [vr_actuators_cli::network::vrp] Received response: ReaderToHost {
+     Running `target/release/protocol_host_rs -vv start --protocol tcp --hostname ubuntu20 --port 6001`
+2020-09-02 15:12:17,703 DEBUG [protocol_host_rs] Found level_filter: DEBUG
+2020-09-02 15:12:17,704 INFO  [protocol_host_rs] Starting up ...
+2020-09-02 15:12:17,704 INFO  [protocol_host_rs::network] Connected to tcp://ubuntu20:6001
+2020-09-02 15:12:17,712 DEBUG [protocol_host_rs::network::vrp] Found Obid/Feig USB Device || Bus 020 Device 009 ID 2737 : 2
+2020-09-02 15:12:17,782 DEBUG [protocol_host_rs::network::vrp] Claiming interface: 0
+2020-09-02 15:12:17,784 DEBUG [protocol_host_rs::network::vrp] Claiming interface: 1
+2020-09-02 15:12:17,784 INFO  [protocol_host_rs::network] Beginning serve() loop ...
+2020-09-02 15:12:22,733 INFO  [protocol_host_rs::network] Received SetRadioFreqPower command for power_level 0.
+2020-09-02 15:12:22,740 DEBUG [protocol_host_rs::network::vrp] Sent Serial Command with 44 bytes: 02002cff8b020101011e0003000884800000000000000000008100000000000000000000000000000000a7e6
+2020-09-02 15:12:22,760 DEBUG [protocol_host_rs::network::vrp] Received Response to Serial Command with 8 bytes: 020008008b009a8d
+2020-09-02 15:12:22,760 INFO  [protocol_host_rs::network::vrp] Received response: ReaderToHost {
     stx: PhantomData,
     alength: 8,
     com_adr: 0,
@@ -132,22 +155,22 @@ jwtrueb@dhcp-10-101-176-87 vr_actuators_cli % cargo run --release -- -vv start -
     data: [],
     crc16: 36250,
 }
-2020-09-02 15:12:22,804 INFO  [vr_actuators_cli::network] Received SystemReset.
-2020-09-02 15:12:22,810 DEBUG [vr_actuators_cli::network::vrp] Sent Serial Command with 8 bytes: 020008ff64003821
-2020-09-02 15:12:22,815 DEBUG [vr_actuators_cli::network::vrp] Received Response to Serial Command with 8 bytes: 020008006400cbe7
+2020-09-02 15:12:22,804 INFO  [protocol_host_rs::network] Received SystemReset.
+2020-09-02 15:12:22,810 DEBUG [protocol_host_rs::network::vrp] Sent Serial Command with 8 bytes: 020008ff64003821
+2020-09-02 15:12:22,815 DEBUG [protocol_host_rs::network::vrp] Received Response to Serial Command with 8 bytes: 020008006400cbe7
 ```
 
 #### Example Client Output
 ```
-jwtrueb@dhcp-10-101-176-87 vr_actuators_cli % cargo run --release -- -vv command --protocol tcp --hostname ubuntu20 --port 6000 commands/set-power-0.txt
+jwtrueb@dhcp-10-101-176-87 protocol_host_rs % cargo run --release -- -vv command --protocol tcp --hostname ubuntu20 --port 6000 commands/set-power-0.txt
     Finished release [optimized] target(s) in 0.08s
-     Running `target/release/vr_actuators_cli -vv command --protocol tcp --hostname ubuntu20 --port 6000 commands/set-power-0.txt`
-2020-09-02 15:11:17,690 DEBUG [vr_actuators_cli] Found level_filter: DEBUG
-2020-09-02 15:11:17,691 INFO  [vr_actuators_cli] Running command: command
-2020-09-02 15:11:17,691 INFO  [vr_actuators_cli::network] Connected to tcp://ubuntu20:6000
+     Running `target/release/protocol_host_rs -vv command --protocol tcp --hostname ubuntu20 --port 6000 commands/set-power-0.txt`
+2020-09-02 15:11:17,690 DEBUG [protocol_host_rs] Found level_filter: DEBUG
+2020-09-02 15:11:17,691 INFO  [protocol_host_rs] Running command: command
+2020-09-02 15:11:17,691 INFO  [protocol_host_rs::network] Connected to tcp://ubuntu20:6000
 2020-09-02 15:11:20,192 DEBUG [zmq] socket dropped
 2020-09-02 15:11:20,192 DEBUG [zmq] context dropped
-jwtrueb@dhcp-10-101-176-87 vr_actuators_cli % echo $?
+jwtrueb@dhcp-10-101-176-87 protocol_host_rs % echo $?
 0
 ```
 

--- a/src/conn/common.rs
+++ b/src/conn/common.rs
@@ -1,4 +1,4 @@
-use crate::obid::*;
+use crate::obid::advanced_protocol;
 use crate::error::*;
 
 #[derive(Debug)]
@@ -18,11 +18,8 @@ pub struct AntennaState {
 }
 pub trait Connection<'a> {
     fn send_command(self: &mut Self, serial_message: advanced_protocol::HostToReader) -> Result<advanced_protocol::ReaderToHost>;
-    // fn reset(self: &mut Self) -> Result<(),()>;
 }
 
 pub trait Context<'a> {
-    type Conn: Connection<'a>;
-
-    fn connection(self: &'a Self) -> Result<Self::Conn>;
+    fn connection(self: &'a Self) -> Result<Box<dyn Connection<'a> + 'a>>;
 }

--- a/src/conn/ethernet.rs
+++ b/src/conn/ethernet.rs
@@ -6,11 +6,12 @@ use std::{sync::mpsc, thread, time::Duration, io::prelude::*};
 
 
 
-/*Notes on Ethernet connection: 
+/*Notes on Ethernet connection:
     Fieg Reader IP: 192.168.10.10, netmask: 255.255.0.0
-    Need to match netmask when setting ip for linked computer (as long as ip address matches reader ip where subnet mask is 255 it should connect.Ex:192.168.1.1 since reader ip is 192.168.10.10 and mask is 255.255.0.0). 
-        Connection succeed with IP set to 192.168.10.1 and netmask 255.255.0.0 via direct link with ethernet cable.
-        Connection succeed with IP set to 192.168.10.1 and netmask 255.255.0.0 with reader and computer connected to seperate ethernet jacks in wall of bench.
+    Need to match netmask when setting ip for linked computer (as long as ip address matches reader ip where subnet mask is 255 it should connect.
+        Ex:192.168.1.1 since reader ip is 192.168.10.10 and mask is 255.255.0.0). 
+            Connection succeed with IP set to 192.168.10.1 and netmask 255.255.0.0 via direct link with ethernet cable.
+            Connection succeed with IP set to 192.168.10.1 and netmask 255.255.0.0 with reader and computer connected to seperate ethernet jacks in wall of bench.
 */
 
 
@@ -108,11 +109,10 @@ impl EthernetConnection {
                 return Err(InternalError::from("Could not connect over ethernet"))
             }
         }
-        
     }
 }
 
-pub struct EthernetContext<'a> { 
+pub struct EthernetContext<'a> {
     pub addr: &'a str,
 }
 
@@ -123,17 +123,15 @@ impl<'a> EthernetContext<'a> {
 }
 
 impl<'a> Context<'a> for EthernetContext<'a> {
-    type Conn = EthernetConnection;
-
-    fn connection(self: &'a Self) -> Result<EthernetConnection> {
-        Ok(EthernetConnection::new(self.addr)?)
+    fn connection(self: &'a Self) -> Result<Box<dyn Connection<'a> + 'a>> {
+        Ok(Box::new(EthernetConnection::new(self.addr)?))
     }
 }
 
-
+#[cfg(feature = "ethernet")]
 #[test]
 fn check_ethernet_connection() -> Result<()> {
-    let _ = simple_logger::init_with_level(log::Level::Debug);
+    let _ = simple_logger::SimpleLogger::new().with_level(log::LevelFilter::Debug).init();
     _panic_after(Duration::from_millis(5000), move || -> (){
         let work = move || -> Result<()>{
             let context = Box::new(EthernetContext::new("192.168.10.10:10001")?);

--- a/src/conn/mock.rs
+++ b/src/conn/mock.rs
@@ -24,10 +24,8 @@ impl MockConnection {
 pub struct MockContext { }
 
 impl<'a> Context<'a> for MockContext {
-    type Conn = MockConnection;
-
-    fn connection(self: &'a Self) -> Result<MockConnection> {
-        Ok(MockConnection::new())
+    fn connection(self: &'a Self) -> Result<Box<dyn Connection<'a> + 'a>> {
+        Ok(Box::new(MockConnection::new()))
     }
 }
 

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -1,4 +1,8 @@
 pub mod common;
-pub mod usb;
+
+#[cfg(feature = "mock")]
 pub mod mock;
+#[cfg(feature = "usb")]
+pub mod usb;
+#[cfg(feature = "ethernet")]
 pub mod ethernet;

--- a/src/conn/usb.rs
+++ b/src/conn/usb.rs
@@ -154,9 +154,7 @@ impl<'a> UsbContext<'a> {
 }
 
 impl<'a> Context<'a> for UsbContext<'a> {
-    type Conn = UsbConnection<'a>;
-
-    fn connection(self: &'a Self) -> Result<UsbConnection<'a>> {
-        Ok(UsbConnection::new(self)?)
+    fn connection(self: &'a Self) -> Result<Box<dyn Connection<'a> + 'a>> {
+        Ok(Box::new(UsbConnection::new(self)?))
     }
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -13,6 +13,7 @@ pub enum InternalError {
     ParseInt(ParseIntError),
     ParseFloat(ParseFloatError),
     SerdeError(serde_json::error::Error),
+    #[cfg(feature = "usb")]
     UsbError(libusb::Error),
     ZmqError(zmq::Error),
     HexError(hex::FromHexError),
@@ -47,6 +48,7 @@ impl fmt::Display for InternalError {
                 log::error!("Encountered serde error: {}", e);
                 e.fmt(f)
             },
+            #[cfg(feature = "usb")]
             InternalError::UsbError(ref e) => {
                 log::error!("Encountered usb error: {}", e);
                 e.fmt(f)
@@ -111,6 +113,7 @@ impl From<serde_json::error::Error> for InternalError {
     }
 }
 
+#[cfg(feature = "usb")]
 impl From<libusb::Error> for InternalError {
     fn from(err: libusb::Error) -> InternalError {
         InternalError::UsbError(err)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
-#![allow(dead_code)]
-
 pub mod network;
 pub mod obid;
-pub mod vrp;
 pub mod conn;
 pub mod error;
+pub mod protocol;

--- a/src/network/client.rs
+++ b/src/network/client.rs
@@ -1,4 +1,5 @@
 use crate::network::common::*;
+use crate::protocol::common::CommandMessage;
 
 pub struct Client {
     net_ctx: NetworkContext

--- a/src/network/common.rs
+++ b/src/network/common.rs
@@ -1,7 +1,4 @@
 
-use crate::vrp;
-
-use serde::{Serialize, Deserialize};
 
 #[allow(dead_code)]
 pub struct NetworkContext {
@@ -70,19 +67,3 @@ impl NetworkContext {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-pub enum CommandMessage {
-    Failure { message: String },
-    Success { },
-
-    Stop { },
-
-    SystemReset { },
-    SetRadioFreqPower { power_level: u8 },
-    CustomCommand { control_byte: u8, data: String, device_required: bool },
-
-    AddFabric { fabric_name: String },
-    RemoveFabric { fabric_name: String },
-    ActuatorsCommand { fabric_name: String, timer_mode_blocks: Option<vrp::vrp::TimerModeBlocks>, actuator_mode_blocks: Option<vrp::vrp::ActuatorModeBlocks>, op_mode_block: Option<vrp::vrp::OpModeBlock>, use_cache: Option<bool>},
-
-}

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -1,9 +1,8 @@
-use crate::vrp::vrp;
 use crate::conn::common::*;
 use crate::network::common::*;
+use crate::protocol::common::*;
+use crate::protocol::{haptic::v0::HapticV0Protocol, mock::MockProtocol};
 use crate::error::*;
-
-use std::collections::HashMap;
 
 
 pub struct ServerContext {
@@ -20,18 +19,25 @@ impl ServerContext {//Need ability to select connection type here?
 
 pub struct Server<'a, 'b> {
     ctx:  &'a ServerContext,
-    protocol: vrp::HapticProtocol<'b>,
-    fabrics: HashMap<String, vrp::Fabric>,
+    protocol: Box<dyn Protocol<'b> + 'b>,
 }
 
 
 impl<'a, 'b> Server<'a, 'b> {
     pub fn new(ctx: &'a ServerContext, conn: Box<dyn Connection<'b> +'b>) -> Result<Server<'a, 'b>> {
-        Ok(Server {
-            ctx,
-            protocol: vrp::HapticProtocol::new(conn),
-            fabrics: HashMap::new(),
-        })
+        if cfg![feature = "hatpic_v0"] {
+            log::info!("Creating HapticV0Protocol instance ...");
+            Ok(Server {
+                ctx,
+                protocol: Box::new(HapticV0Protocol::new(conn)),
+            })
+        } else {
+            log::info!("Creating MockProtocol instance ...");
+            Ok(Server {
+                ctx,
+                protocol: Box::new(MockProtocol::new(conn)),
+            })
+        }
     }
 
     pub fn serve(&mut self) -> Result<bool> {
@@ -57,13 +63,17 @@ impl<'a, 'b> Server<'a, 'b> {
 
                     return Ok(false);
                 },
-
                 CommandMessage::SystemReset { } => {
                     log::debug!("Received SystemReset.");
-                    let reset = self.protocol.system_reset();
+                    let reset = self.protocol.handle_message(&request_message);
 
                     log::info!("Waiting for Feig Reader to reboot after system reset ...");
-                    std::thread::sleep(std::time::Duration::from_millis(1000));
+                    let timeout = if cfg!(any(feature = "haptic_v0")) {
+                        1000
+                    } else {
+                        1
+                    };
+                    std::thread::sleep(std::time::Duration::from_millis(timeout));
                     log::info!("Done waiting for reboot. Trying to reset connection ...");
 
                     let message = if reset.is_ok() { CommandMessage::Success{} } else { CommandMessage::Failure { message: String::from("Failed system reset") } };
@@ -74,69 +84,12 @@ impl<'a, 'b> Server<'a, 'b> {
 
                     return Ok(true);
                 },
-                CommandMessage::SetRadioFreqPower { power_level } => {
-                    log::debug!("Received SetRadioFreqPower command for power_level {:?}.", power_level);
-                    match power_level {
-                        pl if pl == 0 || (pl >= 2 && pl <= 12) => {
-                            self.protocol.set_radio_freq_power(power_level)
-                        },
-                        _ => {
-                            let message = format!("Value for power level ({}) is outside acceptable range Low Power (0) or [2,12].", power_level);
-                            log::error!("{}", message.as_str());
-                            Err(InternalError::from(message.as_str()))
-                        }
-                    }
-                },
-                CommandMessage::CustomCommand { control_byte, data, device_required } => {
-                    log::debug!("Received Custom command with control_byte {} and data {}", hex::encode(vec![control_byte]), hex::encode(data.as_bytes()));
-                    let decoded_data = hex::decode(&data)?;
-                    self.protocol.custom_command(control_byte, decoded_data.as_slice(), device_required)
-                },
-
-                CommandMessage::AddFabric { fabric_name } => {
-                    match vrp::Fabric::new(&mut self.protocol, fabric_name.as_str()) {
-                        Ok(fabric) => {
-                            self.fabrics.insert(fabric_name, fabric);
-
-                            log::info!("Added new fabric to command for AddFabric command");
-                            log::trace!("Active Fabrics: {:#?}", self.fabrics);
-                            Ok(())
-                        },
-                        Err(err) => {
-                            log::error!("Failed to create Fabric: {}", err);
-                            Err(err)
-                        }
-                    }
-
-                },
-                CommandMessage::RemoveFabric { fabric_name } => {
-                    match self.fabrics.remove(&fabric_name) {
-                        Some(fabric) => {
-                            log::info!("Removed existing fabric to command for AddFabric command");
-                            log::trace!("Active Fabrics:  {:#?}", self.fabrics);
-                            log::trace!("Removed Fabric:  {:#?}", fabric);
-                            Ok(())
-                        },
-                        None => {
-                            let message = format!("No existing fabric to remove for RemoveFabric command");
-                            log::error!("{}", message.as_str());
-                            Err(InternalError::from(message.as_str()))
-                        }
-                    }
-                },
-                CommandMessage::ActuatorsCommand { fabric_name, timer_mode_blocks, actuator_mode_blocks, op_mode_block, use_cache } => {
-                    log::debug!("Received ActuatorsCommand: {:#?} {:#?} {:#?} {:#?}", fabric_name, timer_mode_blocks, actuator_mode_blocks, op_mode_block);
-                    self.handle_actuators_command(fabric_name, timer_mode_blocks, actuator_mode_blocks, op_mode_block, use_cache)
-                },
                 CommandMessage::Success { } => {
                     Ok(())
-                }
+                },
 
                 other => {
-                    let failure_message = String::from(format!("Unhandled CommandMessage request: {:#?}", other));
-                    log::error!("{}", failure_message.as_str());
-
-                    return Err(InternalError::from("Unhandled CommandMessage"));
+                    self.protocol.handle_message(&other)
                 }
             };
 
@@ -161,67 +114,5 @@ impl<'a, 'b> Server<'a, 'b> {
     #[allow(dead_code)]
     pub fn get_last_endpoint(self: &Self) -> String {
         self.ctx.net_ctx.socket.get_last_endpoint().unwrap().unwrap()
-    }
-
-    fn handle_actuators_command(self: &mut Self, fabric_name: String, timer_mode_blocks: Option<vrp::TimerModeBlocks>, actuator_mode_blocks: Option<vrp::ActuatorModeBlocks>, op_mode_block: Option<vrp::OpModeBlock>, use_cache: Option<bool>) -> Result<()> {
-        let fabric = match self.fabrics.get_mut(&fabric_name) {
-            Some(fabric) => {
-                log::trace!("Found transponder for actuator command: {:?}", fabric.transponders);
-                fabric
-            },
-            None => {
-                let message = format!("No existing fabric to write actuator command: {:?}", self.fabrics);
-                log::error!("{}", message);
-                return Err(InternalError::from(message.as_str()));
-            }
-        };
-
-        let fabric_uid = match fabric.transponders.len() {
-            t_idx if t_idx > 0 => {
-                &fabric.transponders[0].uid
-            },
-            _ => {
-                return Err(InternalError::from("No transponder UID found for fabric"));
-            }
-        };
-
-        let mut actuators_command = vrp::ActuatorsCommand {
-            fabric_name: fabric_name.clone(),
-            timer_mode_blocks: timer_mode_blocks.clone(),
-            actuator_mode_blocks: actuator_mode_blocks.clone(),
-            op_mode_block: op_mode_block.clone(),
-            use_cache: use_cache.clone(),
-        };
-
-        let actuators_command = match use_cache {
-            Some(flag)  => {
-                if flag {
-                    if fabric.state.state.use_cache.unwrap() {
-                        actuators_command = fabric.state.diff(actuators_command);
-                        log::debug!("Writing using cached diff: {:#?}", &actuators_command);
-                    } else {
-                        log::debug!("Skipping cached diff to warm cache");
-                    }
-                } else {
-                    log::debug!("Command electing to bypass cache");
-                }
-                actuators_command
-            },
-            _ => {
-                if fabric.state.state.use_cache.unwrap() {
-                    actuators_command = fabric.state.diff(actuators_command);
-                    log::debug!("Writing using cached diff: {:#?}", &actuators_command);
-                } else {
-                    log::debug!("Skipping cached diff to warm cache");
-                }
-                actuators_command
-            }
-        };
-
-        let result = self.protocol.actuators_command(fabric_uid.as_slice(), &actuators_command.timer_mode_blocks, &actuators_command.actuator_mode_blocks, &actuators_command.op_mode_block);
-        if result.is_ok() {
-            fabric.state.apply(actuators_command);
-        }
-        result
     }
 }

--- a/src/obid/mod.rs
+++ b/src/obid/mod.rs
@@ -1,5 +1,5 @@
-mod protocol;
+mod serial;
 mod status;
 
-pub use protocol::*;
-pub use status::*;
+pub use self::serial::*;
+pub use self::status::*;

--- a/src/obid/serial.rs
+++ b/src/obid/serial.rs
@@ -262,7 +262,7 @@ mod tests {
 
     #[test]
     fn host_to_reader_no_data() {
-        let _ = simple_logger::init_with_level(log::Level::Debug);
+        let _ = simple_logger::SimpleLogger::new().with_level(log::LevelFilter::Debug).init();
 
         let data = vec![];
         let mut expected_msg = advanced_protocol::HostToReader::new(0, 0, 0,  &data[..], 0, false);
@@ -275,7 +275,7 @@ mod tests {
 
     #[test]
     fn host_to_reader_some_data() {
-        let _ = simple_logger::init_with_level(log::Level::Debug);
+        let _ = simple_logger::SimpleLogger::new().with_level(log::LevelFilter::Debug).init();
 
         let data = vec![1; 10];
         let mut expected_msg = advanced_protocol::HostToReader::new(0, 0, 0,  &data[..], 0, false);
@@ -288,7 +288,7 @@ mod tests {
 
     #[test]
     fn reader_to_host_no_data() {
-        let _ = simple_logger::init_with_level(log::Level::Debug);
+        let _ = simple_logger::SimpleLogger::new().with_level(log::LevelFilter::Debug).init();
 
         let data = vec![];
         let mut expected_msg = advanced_protocol::ReaderToHost::new(8, 0, 0, 0, &data[..], 0);
@@ -301,7 +301,7 @@ mod tests {
 
     #[test]
     fn reader_to_host_some_data() {
-        let _ = simple_logger::init_with_level(log::Level::Debug);
+        let _ = simple_logger::SimpleLogger::new().with_level(log::LevelFilter::Debug).init();
 
         let data = vec![1; 100];
         let mut expected_msg = advanced_protocol::ReaderToHost::new(8, 0, 0, 0, &data[..], 0);
@@ -314,7 +314,7 @@ mod tests {
 
     #[test]
     fn reader_to_host_alotta_data() {
-        let _ = simple_logger::init_with_level(log::Level::Debug);
+        let _ = simple_logger::SimpleLogger::new().with_level(log::LevelFilter::Debug).init();
 
         let data = vec![1; 10000];
         let mut expected_msg = advanced_protocol::ReaderToHost::new(8, 0, 0, 0, &data[..], 0);
@@ -327,7 +327,7 @@ mod tests {
 
     #[test]
     fn reader_to_host_bad_crc() {
-        let _ = simple_logger::init_with_level(log::Level::Debug);
+        let _ = simple_logger::SimpleLogger::new().with_level(log::LevelFilter::Debug).init();
 
         let data = vec![1; 100];
         let mut expected_msg = advanced_protocol::ReaderToHost::new(8, 0, 0, 0, &data[..], 0);
@@ -341,7 +341,7 @@ mod tests {
 
     #[test]
     fn reader_to_host_too_short() {
-        let _ = simple_logger::init_with_level(log::Level::Debug);
+        let _ = simple_logger::SimpleLogger::new().with_level(log::LevelFilter::Debug).init();
 
         let data = vec![1; 100];
         let mut expected_msg = advanced_protocol::ReaderToHost::new(8, 0, 0, 0, &data[..], 0);

--- a/src/protocol/common.rs
+++ b/src/protocol/common.rs
@@ -1,0 +1,43 @@
+
+use crate::error::*;
+use crate::protocol::haptic;
+use core::fmt::Debug;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum CommandMessage {
+    Failure { message: String },
+    Success { },
+
+    Stop { },
+
+    SystemReset { },
+    SetRadioFreqPower { power_level: u8 },
+    CustomCommand { control_byte: u8, data: String, device_required: bool },
+
+    AddFabric { fabric_name: String },
+    RemoveFabric { fabric_name: String },
+    ActuatorsCommand {
+        fabric_name: String,
+        timer_mode_blocks: Option<haptic::v0::TimerModeBlocks>,
+        actuator_mode_blocks: Option<haptic::v0::ActuatorModeBlocks>,
+        op_mode_block: Option<haptic::v0::OpModeBlock>,
+        use_cache: Option<bool>
+    },
+}
+
+pub trait Protocol<'a> {
+    fn handle_message(self: &mut Self, message: &CommandMessage) -> Result<()>;
+}
+
+pub trait Fabric {
+    fn name(self: &Self) -> String;
+    fn identifier(self: &Self) -> Result<std::vec::Vec<u8>>;
+}
+
+impl Debug for dyn Fabric {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Fabric({},{:?})", self.name(), self.identifier())
+    }
+
+}

--- a/src/protocol/haptic/mod.rs
+++ b/src/protocol/haptic/mod.rs
@@ -1,0 +1,1 @@
+pub mod v0;

--- a/src/protocol/mock.rs
+++ b/src/protocol/mock.rs
@@ -1,0 +1,17 @@
+use super::common::*;
+use crate::error::*;
+use crate::conn::common::Connection;
+
+
+pub struct MockProtocol {}
+
+impl MockProtocol {
+    pub fn new(_connection: Box<dyn Connection<'_> + '_>) -> MockProtocol { MockProtocol {}
+    }
+}
+
+impl Protocol<'_> for MockProtocol {
+    fn handle_message(self: &mut Self, _message: &CommandMessage) -> Result<()> {
+        Ok(())
+    }
+}

--- a/src/protocol/mod.rs
+++ b/src/protocol/mod.rs
@@ -1,0 +1,3 @@
+pub mod common;
+pub mod haptic;
+pub mod mock;

--- a/src/vrp/mod.rs
+++ b/src/vrp/mod.rs
@@ -1,1 +1,0 @@
-pub mod vrp;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,218 @@
+
+use protocol_host_lib::error::*;
+
+use std::{sync::mpsc, thread, time::Duration};
+use protocol_host_lib::conn::common::Context;
+
+fn conn_type() -> &'static str {
+    if cfg!(feature = "ethernet") {
+        return "ethernet"
+    } else if cfg!(feature = "usb") {
+        return "usb"
+    } else {
+        return "mock"
+    }
+}
+
+fn panic_after<T, F>(d: Duration, f: F) -> T
+where
+    T: Send + 'static,
+    F: FnOnce() -> T,
+    F: Send + 'static,
+{
+    let (done_tx, done_rx) = mpsc::channel();
+    let handle = thread::spawn(move || {
+        let val = f();
+        done_tx.send(()).expect("Unable to send completion signal");
+        val
+    });
+
+    match done_rx.recv_timeout(d) {
+        Ok(_) => handle.join().expect("Thread panicked"),
+        Err(_) => panic!("Thread took too long"),
+    }
+}
+
+
+pub fn connect_client_to_server(timeout: u64, client_commands: std::vec::Vec<String>) -> Result<()> {
+    // Multiple tests may attempt to re-register the logger
+    let _ = simple_logger::SimpleLogger::new().with_level(log::LevelFilter::Debug).init();
+
+    panic_after(Duration::from_millis(timeout), move || {
+        let proxy_front_endpoint = std::sync::Mutex::new(String::from(""));
+        let proxy_back_endpoint= std::sync::Mutex::new(String::from(""));
+
+        let front_endpoint= std::sync::Arc::new(proxy_front_endpoint);
+        let back_endpoint= std::sync::Arc::new(proxy_back_endpoint);
+
+        let client_endpoint = front_endpoint.clone();
+        let proxy_front = front_endpoint.clone();
+
+        let server_endpoint = back_endpoint.clone();
+        let proxy_back= back_endpoint.clone();
+
+        let ctx = zmq::Context::new();
+        let publisher = ctx.socket(zmq::PUB).unwrap();
+        let any_local_endpoint = protocol_host_lib::network::common::NetworkContext::get_endpoint("tcp", "*", 0);
+        publisher.bind(any_local_endpoint.as_str()).unwrap();
+        let control_endpoint = publisher.get_last_endpoint().unwrap().unwrap();
+        log::info!("Bound control to {:?}", control_endpoint);
+
+        let proxy_handle = std::thread::spawn(move || -> () {
+            log::info!("Starting proxy ...");
+
+            let any_local_endpoint = protocol_host_lib::network::common::NetworkContext::get_endpoint("tcp", "*", 0);
+            let ctx = zmq::Context::new();
+
+            let mut front = ctx.socket(zmq::ROUTER).unwrap();
+            let mut back = ctx.socket(zmq::DEALER).unwrap();
+            let mut control = ctx.socket(zmq::SUB).unwrap();
+            assert!(control.set_subscribe(&vec![]).is_ok());
+
+            log::info!("Binding and connecting proxy sockets ...");
+
+            {
+                let mut front_guard = proxy_front.lock().unwrap();
+                let mut back_guard= proxy_back.lock().unwrap();
+
+                front.bind(any_local_endpoint.as_str()).unwrap();
+                *front_guard = front.get_last_endpoint().unwrap().unwrap();
+                log::info!("Bound front to {:?}", *front_guard);
+
+                back.bind(any_local_endpoint.as_str()).unwrap();
+                *back_guard = back.get_last_endpoint().unwrap().unwrap();
+                log::info!("Bound back to {:?}", *back_guard);
+
+                assert!(control.connect(control_endpoint.as_str()).is_ok());
+                log::info!("Connected control to {:?}", control_endpoint);
+            }
+
+            assert!(zmq::proxy_steerable(&mut front, &mut back, &mut control).is_ok());
+            ()
+        });
+
+        let server_handle = std::thread::spawn(move || -> ()  {
+            let work = move || -> Result<()> {
+                log::info!("Starting server ...");
+
+                let endpoint;
+                loop {
+                    {
+                        let guard = server_endpoint.lock().unwrap();
+                        if !guard.is_empty() {
+                            endpoint = guard.clone();
+                            break;
+                        }
+                    }
+
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                }
+
+                #[allow(unused_variables)]
+                #[cfg(feature = "usb")]
+                let libusb_context = libusb::Context::new()?;
+                let server_context = protocol_host_lib::network::server::ServerContext::new((&endpoint).clone())?;
+
+                loop {
+                    let serve_again = match conn_type() {
+                        "mock" => {
+                            let context = Box::new(protocol_host_lib::conn::mock::MockContext::new());
+                            let connection = context.connection()?;
+                            start_server_with_connection(connection, &server_context)
+                        },
+                        #[cfg(feature = "usb")]
+                        "usb" => {
+                            let context = Box::new(protocol_host_lib::conn::usb::UsbContext::new(&libusb_context)?);
+                            let connection = context.connection()?;
+                            start_server_with_connection(connection, &server_context)
+                        },
+                        #[cfg(feature = "ethernet")]
+                        "ethernet" => {
+                            let context = Box::new(protocol_host_lib::conn::ethernet::EthernetContext::new("192.168.10.10:10001")?);
+                            let connection = context.connection()?;
+                            start_server_with_connection(connection, &server_context)
+                        },
+                        _ => return Err(InternalError::from("No conn_type")),
+                    };
+
+                    log::info!("Finished serving with {:?}", serve_again);
+                    match serve_again {
+                        Ok(true) => {
+                            log::info!("Continuing to serve ...");
+                        },
+                        Ok(false) => return Ok(()),
+                        Err(err) => {
+                            log::error!("Stopping serve due to: {:?}", err);
+                            return Err(err);
+                        }
+                    }
+                }
+            };
+            match work() {
+                Err(err) => panic!("{}",err),
+                _ => ()
+            }
+        });
+
+        let client_handle = std::thread::spawn(move || {
+            let endpoint;
+            loop {
+                {
+                    let guard = client_endpoint.lock().unwrap();
+                    if !guard.is_empty() {
+                        endpoint = guard.clone();
+                        break;
+                    }
+                }
+
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+
+            log::info!("Starting client ...");
+
+            let client = protocol_host_lib::network::client::Client::new(endpoint);
+            assert!(client.is_ok());
+            let mut client = client.unwrap();
+
+            let mut client_commands = client_commands;
+            client_commands.push(String::from(r#"{ "Stop": {} }"#));
+
+            log::info!("Running client commands:");
+            for command in &client_commands {
+                log::info!("{}", command);
+            }
+
+            for command in &client_commands {
+                let command_stream = serde_json::Deserializer::from_str(command.as_str()).into_iter::<protocol_host_lib::protocol::common::CommandMessage>();
+                for command in command_stream {
+                    assert!(command.is_ok());
+                    let result = client.request_message(command.unwrap());
+                    assert!(result.is_ok());
+                }
+            }
+            ()
+        });
+
+        let server_result = server_handle.join();
+        log::info!("Server is finished.");
+        let client_result = client_handle.join();
+        log::info!("Client is finished.");
+        assert!(client_result.is_ok());
+        assert!(server_result.is_ok());
+
+        log::info!("Signaling proxy to terminate");
+        assert!(publisher.send("TERMINATE".to_ascii_uppercase().as_bytes(), 0).is_ok());
+
+        log::info!("Waiting for proxy to finish ...");
+        let proxy_result = proxy_handle.join();
+        assert!(proxy_result.is_ok());
+        log::info!("Success");
+    });
+
+    Ok(())
+}
+
+fn start_server_with_connection<'a, 'b>(connection: Box<dyn protocol_host_lib::conn::common::Connection<'a> + 'a>, server_context: &'b protocol_host_lib::network::server::ServerContext) -> Result<bool> {
+    let mut server = protocol_host_lib::network::server::Server::new(server_context, connection).expect("Failed to initialize server");
+    server.serve()
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,269 +1,69 @@
-extern crate vr_actuators_cli;
+use protocol_host_lib::error::*;
 
-use std::{sync::mpsc, thread, time::Duration};
-use vr_actuators_cli::conn::common::Context;
-use vr_actuators_cli::error::*;
+mod common;
 
-fn panic_after<T, F>(d: Duration, f: F) -> T
-where
-    T: Send + 'static,
-    F: FnOnce() -> T,
-    F: Send + 'static,
-{
-    let (done_tx, done_rx) = mpsc::channel();
-    let handle = thread::spawn(move || {
-        let val = f();
-        done_tx.send(()).expect("Unable to send completion signal");
-        val
-    });
-
-    match done_rx.recv_timeout(d) {
-        Ok(_) => handle.join().expect("Thread panicked"),
-        Err(_) => panic!("Thread took too long"),
-    }
-}
-
-
-fn connect_client_to_server(timeout: u64, client_commands: std::vec::Vec<String>, conn_type: &'static str) -> Result<()> {
-    // Multiple tests may attempt to re-register the logger
-    let _ = simple_logger::init_with_level(log::Level::Debug);
-
-    panic_after(Duration::from_millis(timeout), move || {
-        let proxy_front_endpoint = std::sync::Mutex::new(String::from(""));
-        let proxy_back_endpoint= std::sync::Mutex::new(String::from(""));
-
-        let front_endpoint= std::sync::Arc::new(proxy_front_endpoint);
-        let back_endpoint= std::sync::Arc::new(proxy_back_endpoint);
-
-        let client_endpoint = front_endpoint.clone();
-        let proxy_front = front_endpoint.clone();
-
-        let server_endpoint = back_endpoint.clone();
-        let proxy_back= back_endpoint.clone();
-
-        let ctx = zmq::Context::new();
-        let publisher = ctx.socket(zmq::PUB).unwrap();
-        let any_local_endpoint = vr_actuators_cli::network::common::NetworkContext::get_endpoint("tcp", "*", 0);
-        publisher.bind(any_local_endpoint.as_str()).unwrap();
-        let control_endpoint = publisher.get_last_endpoint().unwrap().unwrap();
-        log::info!("Bound control to {:?}", control_endpoint);
-
-        let proxy_handle = std::thread::spawn(move || -> () {
-            log::info!("Starting proxy ...");
-
-            let any_local_endpoint = vr_actuators_cli::network::common::NetworkContext::get_endpoint("tcp", "*", 0);
-            let ctx = zmq::Context::new();
-
-            let mut front = ctx.socket(zmq::ROUTER).unwrap();
-            let mut back = ctx.socket(zmq::DEALER).unwrap();
-            let mut control = ctx.socket(zmq::SUB).unwrap();
-            assert!(control.set_subscribe(&vec![]).is_ok());
-
-            log::info!("Binding and connecting proxy sockets ...");
-
-            {
-                let mut front_guard = proxy_front.lock().unwrap();
-                let mut back_guard= proxy_back.lock().unwrap();
-
-                front.bind(any_local_endpoint.as_str()).unwrap();
-                *front_guard = front.get_last_endpoint().unwrap().unwrap();
-                log::info!("Bound front to {:?}", *front_guard);
-
-                back.bind(any_local_endpoint.as_str()).unwrap();
-                *back_guard = back.get_last_endpoint().unwrap().unwrap();
-                log::info!("Bound back to {:?}", *back_guard);
-
-                assert!(control.connect(control_endpoint.as_str()).is_ok());
-                log::info!("Connected control to {:?}", control_endpoint);
-            }
-
-            assert!(zmq::proxy_steerable(&mut front, &mut back, &mut control).is_ok());
-            ()
-        });
-
-        let server_handle = std::thread::spawn(move || -> ()  {
-            let work = move || -> Result<()> {
-                log::info!("Starting server ...");
-
-                let endpoint;
-                loop {
-                    {
-                        let guard = server_endpoint.lock().unwrap();
-                        if !guard.is_empty() {
-                            endpoint = guard.clone();
-                            break;
-                        }
-                    }
-
-                    std::thread::sleep(std::time::Duration::from_millis(100));
-                }
-                
-                loop {
-                    let libusb_context = libusb::Context::new()?;
-                    //Lifetime issues if not outside match statement
-                    let usbcontext = Box::new(vr_actuators_cli::conn::usb::UsbContext::new(&libusb_context)?);  
-                    
-                    let server_context = vr_actuators_cli::network::server::ServerContext::new((&endpoint).clone())?;
-                    
-                    let conn: Box<dyn vr_actuators_cli::conn::common::Connection> = match conn_type {
-                        "mock" => {
-                            let context = Box::new(vr_actuators_cli::conn::mock::MockContext::new());
-                            Box::new(context.connection()?)
-                        },
-                        "usb" => {
-                            Box::new(usbcontext.connection()?)
-                        },
-                        "ethernet" => {
-                            let context = Box::new(vr_actuators_cli::conn::ethernet::EthernetContext::new("192.168.10.10:10001")?);
-                            Box::new(context.connection()?)
-                        },
-                        _ => {return Err(InternalError::from("No conn_type"));},
-                    };
-
-                    let mut server = vr_actuators_cli::network::server::Server::new(&server_context, conn)?;
-
-                    let endpoint = server.get_last_endpoint();
-                    log::info!("Server connected to: {}", endpoint);
-                    {
-                        *server_endpoint.lock().unwrap() = endpoint;
-                    }
-
-                    match server.serve() {
-                        Ok(false) => {
-                            log::info!("Finished serving with Ok result.");
-                            return Ok(());
-                        },
-                        Ok(true) => {
-                            log::info!("Continuing serve loop");
-                        }
-                        Err(err) => {
-                            log::error!("Failed to server: {}", err);
-                            return Err(err);
-                        }
-                    }
-                }
-            };
-            match work() {
-                Err(err) => panic!("{}",err),
-                _ => ()
-            }
-        });
-
-        let client_handle = std::thread::spawn(move || {
-            let endpoint;
-            loop {
-                {
-                    let guard = client_endpoint.lock().unwrap();
-                    if !guard.is_empty() {
-                        endpoint = guard.clone();
-                        break;
-                    }
-                }
-
-                std::thread::sleep(std::time::Duration::from_millis(100));
-            }
-
-            log::info!("Starting client ...");
-
-            let client = vr_actuators_cli::network::client::Client::new(endpoint);
-            assert!(client.is_ok());
-            let mut client = client.unwrap();
-
-            let mut client_commands = client_commands;
-            client_commands.push(String::from(r#"{ "Stop": {} }"#));
-
-            log::info!("Running client commands:");
-            for command in &client_commands {
-                log::info!("{}", command);
-            }
-
-            for command in &client_commands {
-                let command_stream = serde_json::Deserializer::from_str(command.as_str()).into_iter::<vr_actuators_cli::network::common::CommandMessage>();
-                for command in command_stream {
-                    assert!(command.is_ok());
-                    let result = client.request_message(command.unwrap());
-                    assert!(result.is_ok());
-                }
-            }
-            ()
-        });
-
-        let server_result = server_handle.join();
-        log::info!("Server is finished.");
-        let client_result = client_handle.join();
-        log::info!("Client is finished.");
-        assert!(client_result.is_ok());
-        assert!(server_result.is_ok());
-
-        log::info!("Signaling proxy to terminate");
-        assert!(publisher.send("TERMINATE".to_ascii_uppercase().as_bytes(), 0).is_ok());
-
-        log::info!("Waiting for proxy to finish ...");
-        let proxy_result = proxy_handle.join();
-        assert!(proxy_result.is_ok());
-        log::info!("Success");
-    });
-
-    Ok(())
-}
+use common::*;
 
 #[test]
 fn nop_serve_to_client() -> Result<()> {
-    connect_client_to_server(2000, vec![]
-        // ,"mock")
-    ,"ethernet")
+    connect_client_to_server(2000, vec![])
 }
 
 #[test]
 fn system_reset() -> Result<()> {
-    connect_client_to_server(15000, vec![
-        String::from(r#"{ "SystemReset": { } }"#),
-    ]
-    // ,"mock")
-    ,"ethernet")
+    #[allow(unused_variables)]
+    let timeout = 10000;
+    #[cfg(any(feature = "usb", feature = "ethernet"))]
+    let timeout = 10000;
+    connect_client_to_server(timeout, vec![ String::from(r#"{ "SystemReset": { } }"#), ])
 }
 
 #[test]
 fn connect_to_fabric() -> Result<()> {
-    connect_client_to_server(10000, vec![
+    #[allow(unused_variables)]
+    let timeout = 1000;
+    #[cfg(any(feature = "usb", feature = "ethernet"))]
+    let timeout = 10000;
+    connect_client_to_server(timeout, vec![
         String::from(r#"{ "AddFabric": { "fabric_name": "Obid Feig LRM2500-B" } }"#),
-    ]
-    // ,"mock")
-    ,"ethernet")
+    ])
 }
 
 #[test]
 fn set_the_power_level() -> Result<()> {
-    connect_client_to_server(10000, vec![
+    #[allow(unused_variables)]
+    let timeout = 500;
+    #[cfg(any(feature = "usb", feature = "ethernet"))]
+    let timeout = 10000;
+    connect_client_to_server(timeout, vec![
         String::from(r#"{ "SetRadioFreqPower": { "power_level": 4 } }"#),
         String::from(r#"{ "SystemReset": { } }"#),
-    ]
-    // ,"mock")
-    ,"ethernet")
+    ])
 }
 
 #[test]
 fn set_the_power_level_low_power() -> Result<()> {
-    connect_client_to_server(5000, vec![
+    #[allow(unused_variables)]
+    let timeout = 500;
+    #[cfg(any(feature = "usb", feature = "ethernet"))]
+    let timeout = 10000;
+    connect_client_to_server(timeout, vec![
         String::from(r#"{ "SetRadioFreqPower": { "power_level": 0 } }"#),
         String::from(r#"{ "SystemReset": { } }"#),
-    ]
-    ,"mock")
-    // ,"ethernet")
+    ])
 }
 
 #[test]
 fn e2e_pulsing_after_antenna_reset() -> Result<()> {
+    #[allow(unused_variables)]
+    let timeout = 500;
+    #[cfg(any(feature = "usb", feature = "ethernet"))]
+    let timeout = 10000;
     // Reset the conditions of the antenna
-    connect_client_to_server(10000, vec![
+    connect_client_to_server(timeout, vec![
         String::from(r#"{ "SetRadioFreqPower": { "power_level": 2 } }"#),
         String::from(r#"{ "SystemReset": { } }"#),
-    ]
-    // ,"mock")?;
-    ,"ethernet")?;
-
-    // Allow the antenna time to come back online
-    std::thread::sleep(std::time::Duration::from_secs(5));
+    ])?;
 
     // Run the end to end pulsing routine
     e2e_pulsing()
@@ -272,7 +72,7 @@ fn e2e_pulsing_after_antenna_reset() -> Result<()> {
 #[test]
 fn e2e_pulsing() -> Result<()> {
     // Issues commands to enable all actuators in the single fabric of 36 in continuous 50 ms on 50 ms off
-    let op_mode_block = vr_actuators_cli::vrp::vrp::OpModeBlock {
+    let op_mode_block = protocol_host_lib::protocol::haptic::v0::OpModeBlock {
         act_cnt32: 0x02, // ceil(36.0 / 32.0) = 2
         act_mode: 0x00,
         op_mode: 0x02,
@@ -281,26 +81,26 @@ fn e2e_pulsing() -> Result<()> {
 
     let hf_duty_cycle = 30;
     let hf_period = 150;
-    let actuator_mode_blocks = vr_actuators_cli::vrp::vrp::ActuatorModeBlocks {
-        block0_31: Some(vr_actuators_cli::vrp::vrp::ActuatorModeBlock {
+    let actuator_mode_blocks = protocol_host_lib::protocol::haptic::v0::ActuatorModeBlocks {
+        block0_31: Some(protocol_host_lib::protocol::haptic::v0::ActuatorModeBlock {
             b0: 0x0F, // Enable all 8 acutators
             b1: 0x00, // Enable all 8 acutators
             b2: 0x00, // Enable all 8 acutators
             b3: 0x00, // Enable all 8 acutators
         }),
-        block32_63: Some(vr_actuators_cli::vrp::vrp::ActuatorModeBlock {
+        block32_63: Some(protocol_host_lib::protocol::haptic::v0::ActuatorModeBlock {
             b0: 0x00, // Enable last 4 actuators
             b1: 0x00,
             b2: 0x00,
             b3: 0x00,
         }),
-        block64_95: Some(vr_actuators_cli::vrp::vrp::ActuatorModeBlock {
+        block64_95: Some(protocol_host_lib::protocol::haptic::v0::ActuatorModeBlock {
             b0: 0x00,
             b1: 0x00,
             b2: 0x00,
             b3: 0x00,
         }),
-        block96_127: Some(vr_actuators_cli::vrp::vrp::ActuatorModeBlock {
+        block96_127: Some(protocol_host_lib::protocol::haptic::v0::ActuatorModeBlock {
             b0: 0x00,
             b1: 0x00,
             b2: 0x00,
@@ -309,14 +109,14 @@ fn e2e_pulsing() -> Result<()> {
     };
     let actuator_mode_blocks = serde_json::to_string(&actuator_mode_blocks)?;
 
-    let timer_mode_blocks = vr_actuators_cli::vrp::vrp::TimerModeBlocks {
+    let timer_mode_blocks = protocol_host_lib::protocol::haptic::v0::TimerModeBlocks {
        /*
         * In single pulse operation, the variable t_pulse[ms] (16 bits) determines the time the pulse will remain on.
         * The high frequency signal (carrier) timing is given by block 6 (0x18).
         *
         * In gestures, t_pulse[ms] (16 bits) and t_pause[ms] (16 bits) control the the on and pause timing
         */
-        single_pulse_block: Some(vr_actuators_cli::vrp::vrp::TimerModeBlock {
+        single_pulse_block: Some(protocol_host_lib::protocol::haptic::v0::TimerModeBlock {
             b0: 0x00,
             b1: 0x00,
             b2: 0x00,
@@ -329,7 +129,7 @@ fn e2e_pulsing() -> Result<()> {
          * The duty cycle is given in time on instead of % of period to avoid calculations in the microcontroller.
          * If ton_high is equal to the T_high, this high frequency signal is overridden by software in the microcontroller.
         */
-        hf_block: Some(vr_actuators_cli::vrp::vrp::TimerModeBlock {
+        hf_block: Some(protocol_host_lib::protocol::haptic::v0::TimerModeBlock {
             b0: ((hf_duty_cycle & 0x00FF)) as u8,
             b1: ((hf_duty_cycle & 0xFF00) >> 8) as u8,
             b2: ((hf_period & 0x00FF)) as u8,
@@ -342,7 +142,7 @@ fn e2e_pulsing() -> Result<()> {
          * The duty cycle is given in time on instead of % of period to avoid calculations in the microcontroller.
          * If ton_high is equal to the T_high, this high frequency signal is overridden by software in the microcontroller.
          */
-        lf_block: Some(vr_actuators_cli::vrp::vrp::TimerModeBlock {
+        lf_block: Some(protocol_host_lib::protocol::haptic::v0::TimerModeBlock {
             b0: 0xFF, // ((4000 & 0x00FF)) as u8,
             b1: 0xFF, // ((4000 & 0xFF00) >> 8) as u8,
             b2: 0xFF, // ((4000 & 0x00FF)) as u8,
@@ -352,21 +152,21 @@ fn e2e_pulsing() -> Result<()> {
     let timer_mode_blocks= serde_json::to_string(&timer_mode_blocks)?;
 
 
-    connect_client_to_server(150000, vec![
+    #[allow(unused_variables)]
+    let timeout = 500;
+    #[cfg(any(feature = "usb", feature = "ethernet"))]
+    let timeout = 30000;
+    connect_client_to_server(timeout, vec![
         String::from(r#"{ "AddFabric": { "fabric_name": "Jacob's Test Actuator Block of 36" } }"#),
         String::from(format!(r#"{{ "ActuatorsCommand": {{  "fabric_name": "Jacob's Test Actuator Block of 36", "op_mode_block": {}, "actuator_mode_blocks": {}, "timer_mode_blocks": {} }} }}"#, op_mode_block, actuator_mode_blocks, timer_mode_blocks)),
         // String::from(format!(r#"{{ "ActuatorsCommand": {{  "fabric_name": "Jacob's Test Actuator Block of 36", "op_mode_block": {} }} }}"#, op_mode_block)),
-    ]
-    // ,"mock")?;
-    ,"ethernet")?;
-
-    Ok(())
+    ])
 }
 
 #[test]
 fn send_all_off() -> Result<()> {
     // Issues commands to enable all actuators in the single fabric of 36 in continuous 50 ms on 50 ms off
-    let op_mode_block = vr_actuators_cli::vrp::vrp::OpModeBlock {
+    let op_mode_block = protocol_host_lib::protocol::haptic::v0::OpModeBlock {
         act_cnt32: 0x02, // ceil(36.0 / 32.0) = 2
         act_mode: 0x00,
         op_mode: 0x00,
@@ -375,26 +175,26 @@ fn send_all_off() -> Result<()> {
 
     let hf_duty_cycle = 30;
     let hf_period = 150;
-    let actuator_mode_blocks = vr_actuators_cli::vrp::vrp::ActuatorModeBlocks {
-        block0_31: Some(vr_actuators_cli::vrp::vrp::ActuatorModeBlock {
+    let actuator_mode_blocks = protocol_host_lib::protocol::haptic::v0::ActuatorModeBlocks {
+        block0_31: Some(protocol_host_lib::protocol::haptic::v0::ActuatorModeBlock {
             b0: 0x00, // Enable all 8 acutators
             b1: 0x00, // Enable all 8 acutators
             b2: 0x00, // Enable all 8 acutators
             b3: 0x00, // Enable all 8 acutators
         }),
-        block32_63: Some(vr_actuators_cli::vrp::vrp::ActuatorModeBlock {
+        block32_63: Some(protocol_host_lib::protocol::haptic::v0::ActuatorModeBlock {
             b0: 0x00, // Enable last 4 actuators
             b1: 0x00,
             b2: 0x00,
             b3: 0x00,
         }),
-        block64_95: Some(vr_actuators_cli::vrp::vrp::ActuatorModeBlock {
+        block64_95: Some(protocol_host_lib::protocol::haptic::v0::ActuatorModeBlock {
             b0: 0x00,
             b1: 0x00,
             b2: 0x00,
             b3: 0x00,
         }),
-        block96_127: Some(vr_actuators_cli::vrp::vrp::ActuatorModeBlock {
+        block96_127: Some(protocol_host_lib::protocol::haptic::v0::ActuatorModeBlock {
             b0: 0x00,
             b1: 0x00,
             b2: 0x00,
@@ -403,14 +203,14 @@ fn send_all_off() -> Result<()> {
     };
     let actuator_mode_blocks = serde_json::to_string(&actuator_mode_blocks)?;
 
-    let timer_mode_blocks = vr_actuators_cli::vrp::vrp::TimerModeBlocks {
+    let timer_mode_blocks = protocol_host_lib::protocol::haptic::v0::TimerModeBlocks {
        /*
         * In single pulse operation, the variable t_pulse[ms] (16 bits) determines the time the pulse will remain on.
         * The high frequency signal (carrier) timing is given by block 6 (0x18).
         *
         * In gestures, t_pulse[ms] (16 bits) and t_pause[ms] (16 bits) control the the on and pause timing
         */
-        single_pulse_block: Some(vr_actuators_cli::vrp::vrp::TimerModeBlock {
+        single_pulse_block: Some(protocol_host_lib::protocol::haptic::v0::TimerModeBlock {
             b0: 0x00,
             b1: 0x00,
             b2: 0x00,
@@ -423,7 +223,7 @@ fn send_all_off() -> Result<()> {
          * The duty cycle is given in time on instead of % of period to avoid calculations in the microcontroller.
          * If ton_high is equal to the T_high, this high frequency signal is overridden by software in the microcontroller.
         */
-        hf_block: Some(vr_actuators_cli::vrp::vrp::TimerModeBlock {
+        hf_block: Some(protocol_host_lib::protocol::haptic::v0::TimerModeBlock {
             b0: ((hf_duty_cycle & 0x00FF)) as u8,
             b1: ((hf_duty_cycle & 0xFF00) >> 8) as u8,
             b2: ((hf_period & 0x00FF)) as u8,
@@ -436,7 +236,7 @@ fn send_all_off() -> Result<()> {
          * The duty cycle is given in time on instead of % of period to avoid calculations in the microcontroller.
          * If ton_high is equal to the T_high, this high frequency signal is overridden by software in the microcontroller.
          */
-        lf_block: Some(vr_actuators_cli::vrp::vrp::TimerModeBlock {
+        lf_block: Some(protocol_host_lib::protocol::haptic::v0::TimerModeBlock {
             b0: 0xFF, // ((4000 & 0x00FF)) as u8,
             b1: 0xFF, // ((4000 & 0xFF00) >> 8) as u8,
             b2: 0xFF, // ((4000 & 0x00FF)) as u8,
@@ -446,13 +246,13 @@ fn send_all_off() -> Result<()> {
     let timer_mode_blocks= serde_json::to_string(&timer_mode_blocks)?;
 
 
-    connect_client_to_server(150000, vec![
+    #[allow(unused_variables)]
+    let timeout = 500;
+    #[cfg(any(feature = "usb", feature = "ethernet"))]
+    let timeout = 30000;
+    connect_client_to_server(timeout, vec![
         String::from(r#"{ "AddFabric": { "fabric_name": "Jacob's Test Actuator Block of 36" } }"#),
         String::from(format!(r#"{{ "ActuatorsCommand": {{  "fabric_name": "Jacob's Test Actuator Block of 36", "op_mode_block": {}, "actuator_mode_blocks": {}, "timer_mode_blocks": {} }} }}"#, op_mode_block, actuator_mode_blocks, timer_mode_blocks)),
         // String::from(format!(r#"{{ "ActuatorsCommand": {{  "fabric_name": "Jacob's Test Actuator Block of 36", "op_mode_block": {} }} }}"#, op_mode_block)),
-    ]
-    // ,"mock")?;
-    ,"ethernet")?;
-
-    Ok(())
+    ])
 }


### PR DESCRIPTION
Key points:

1. protocol_host_rs is the name of the package. there is a protocol_host_lib for the majority of the code and a protocol_host_cli for the main
2. servers mostly don't know how to handle CommandMessages anymore, they call `self.protocol.handle_message`, so the protocol holds a reference to the connection and manages state and fabric changes over time.
3. feature flags compile in what connections and protocols are available/in-use. note the README changes