### PR TITLE
Updates command building for new firmware

### DIFF
--- a/src/conn/common.rs
+++ b/src/conn/common.rs
@@ -11,8 +11,8 @@ pub struct AntennaState {
     pub lf_mod: Option<i32>,
     pub act_block_count: Option<i32>,
 
-    pub op_mode: Option<String>,
-    pub act_mode: Option<String>,
+    pub command: Option<String>,
+    pub cmd_op: Option<String>,
 
     pub max_attempts: i32,
 }

--- a/src/conn/ethernet.rs
+++ b/src/conn/ethernet.rs
@@ -48,8 +48,6 @@ impl<'a> Connection<'a> for EthernetConnection {
                     continue
                 }
             }
-            log::debug!("Sleep for 50ms");
-            std::thread::sleep(std::time::Duration::from_millis(50));
             // Interpret the response
             let response = advanced_protocol::ReaderToHost::deserialize(&self.response_message_buffer[..response_message_size])?;
             log::trace!("Interpretting response for attempt {}: {:#?}", attempts, response);

--- a/src/conn/ethernet.rs
+++ b/src/conn/ethernet.rs
@@ -36,7 +36,7 @@ impl<'a> Connection<'a> for EthernetConnection {
                     return Err(InternalError::from(err));
                 }
             }
-        attempts += 1;
+            attempts += 1;
             let response_message_size ;
             match self.stream.read(self.response_message_buffer.as_mut_slice()) {
                 Ok(bytes_read) => {
@@ -48,7 +48,8 @@ impl<'a> Connection<'a> for EthernetConnection {
                     continue
                 }
             }
-
+            log::debug!("Sleep for 50ms");
+            std::thread::sleep(std::time::Duration::from_millis(50));
             // Interpret the response
             let response = advanced_protocol::ReaderToHost::deserialize(&self.response_message_buffer[..response_message_size])?;
             log::trace!("Interpretting response for attempt {}: {:#?}", attempts, response);
@@ -94,8 +95,8 @@ impl EthernetConnection {
                             hf_mod: None,
                             lf_mod: None,
 
-                            op_mode: None,
-                            act_mode: None,
+                            command: None,
+                            cmd_op: None,
                             act_block_count: None,
 
                             max_attempts: 5

--- a/src/conn/usb.rs
+++ b/src/conn/usb.rs
@@ -124,8 +124,8 @@ impl<'a> UsbConnection<'a> {
                             hf_mod: None,
                             lf_mod: None,
 
-                            op_mode: None,
-                            act_mode: None,
+                            command: None,
+                            cmd_op: None,
                             act_block_count: None,
 
                             max_attempts: 5

--- a/src/network/server.rs
+++ b/src/network/server.rs
@@ -25,7 +25,7 @@ pub struct Server<'a, 'b> {
 
 impl<'a, 'b> Server<'a, 'b> {
     pub fn new(ctx: &'a ServerContext, conn: Box<dyn Connection<'b> +'b>) -> Result<Server<'a, 'b>> {
-        if cfg![feature = "hatpic_v0"] {
+        if cfg![feature = "haptic_v0"] {
             log::info!("Creating HapticV0Protocol instance ...");
             Ok(Server {
                 ctx,

--- a/src/protocol/common.rs
+++ b/src/protocol/common.rs
@@ -15,6 +15,8 @@ pub enum CommandMessage {
     SetRadioFreqPower { power_level: u8 },
     CustomCommand { control_byte: u8, data: String, device_required: bool },
 
+    RfFieldState {state: u8},
+
     AddFabric { fabric_name: String },
     RemoveFabric { fabric_name: String },
     ActuatorsCommand {

--- a/src/protocol/haptic/v0.rs
+++ b/src/protocol/haptic/v0.rs
@@ -467,10 +467,10 @@ impl<'a> HapticV0Protocol<'a> {
                         if is_actuators { 
                             cmd_op = 3; //Actuator command with timing config
                             //Fill memory blocks with space
-                            while mem_blk2.len() < 4 { 
+                            while mem_blk2.len() < 4 && blks.len() != 0 { 
                                 mem_blk2.push(blks.remove(0));
                             }
-                            while mem_blk3.len() < 4 {
+                            while mem_blk3.len() < 4 && blks.len() != 0 {
                                 mem_blk3.push(blks.remove(0));
                             }
                         } else { //Only setting timing blocks
@@ -485,7 +485,15 @@ impl<'a> HapticV0Protocol<'a> {
                         }
                     }
                 }                        
-                
+                while mem_blk2.len() > 0 && mem_blk2.len() < 4 { //Need to fill memory blocks if not full
+                    mem_blk2.push(0);
+                }
+                if mem_blk2.len() == 0 && is_actuators {
+                    mem_blk2 = vec![0,0,0,0];
+                }
+                while mem_blk3.len() > 0 && mem_blk3.len() < 4 {
+                    mem_blk3.push(0);
+                } 
                 let op_mode = cmd_op << 5 | act_cnt8;
                 mem_blk1[1] = op_mode;
 
@@ -494,7 +502,6 @@ impl<'a> HapticV0Protocol<'a> {
                 num_bytes = mem_blk1.len()+mem_blk2.len()+mem_blk3.len();
                 mem_blk1[0] = num_bytes as u8;
                 data[11] = ((num_bytes as f32/4f32).ceil()) as u8; //calcuate number of memeory blocks to write to
-                
                 mem_blk1.reverse();
                 mem_blk2.reverse();
                 mem_blk3.reverse();

--- a/src/protocol/haptic/v0.rs
+++ b/src/protocol/haptic/v0.rs
@@ -527,6 +527,9 @@ impl<'a> HapticV0Protocol<'a> {
 impl<'a> Protocol<'a> for HapticV0Protocol<'a> {
     fn handle_message(self: &mut Self, message: &CommandMessage) -> Result<()> {
         match message {
+            CommandMessage::RfFieldState { state} => {
+                self.custom_command(0x6A, vec![*state].as_slice(), false)
+            }
             CommandMessage::AddFabric { fabric_name } => {
                 let uid = match self.get_inventory(true) {
                     Ok(uid) => uid,

--- a/src/protocol/haptic/v0.rs
+++ b/src/protocol/haptic/v0.rs
@@ -122,7 +122,6 @@ impl V0FabricState {
     pub fn apply(self: &mut Self, new_state: ActuatorsCommand) {
         let diff = self.diff(new_state);
 
-        let new_actuator_blocks = &diff.actuator_mode_blocks.unwrap_or(self.state.actuator_mode_blocks.clone().unwrap());
         let curr_actuator_blocks = self.state.actuator_mode_blocks.as_ref().unwrap();
 
         let new_timer_blocks = &diff.timer_mode_blocks.unwrap_or(self.state.timer_mode_blocks.clone().unwrap());
@@ -133,10 +132,10 @@ impl V0FabricState {
             fabric_name: self.state.fabric_name.clone(),
             op_mode_block: diff.op_mode_block,
             actuator_mode_blocks: Some(ActuatorModeBlocks {
-                block0_31: if new_actuator_blocks.block0_31.is_some() { new_actuator_blocks.block0_31.clone() } else { curr_actuator_blocks.block0_31.clone() },
-                block32_63: if new_actuator_blocks.block32_63.is_some() { new_actuator_blocks.block32_63.clone() } else { curr_actuator_blocks.block32_63.clone() },
-                block64_95: if new_actuator_blocks.block64_95.is_some() { new_actuator_blocks.block64_95.clone() } else { curr_actuator_blocks.block64_95.clone() },
-                block96_127: if new_actuator_blocks.block96_127.is_some() { new_actuator_blocks.block96_127.clone() } else { curr_actuator_blocks.block96_127.clone() },
+                block0_31: curr_actuator_blocks.block0_31.clone(),
+                block32_63: curr_actuator_blocks.block32_63.clone(),
+                block64_95: curr_actuator_blocks.block64_95.clone(),
+                block96_127: curr_actuator_blocks.block96_127.clone(),
             }),
             timer_mode_blocks: Some(TimerModeBlocks {
                 single_pulse_block: if new_timer_blocks.single_pulse_block.is_some() { new_timer_blocks.single_pulse_block.clone() } else { curr_timer_blocks.single_pulse_block.clone() },

--- a/src/protocol/haptic/v0.rs
+++ b/src/protocol/haptic/v0.rs
@@ -412,35 +412,49 @@ impl<'a> HapticV0Protocol<'a> {
         let addr = 0x00;
         
         let mut data: smallvec::SmallVec<[u8; 32]> = smallvec::smallvec![command_id, mode, uid[0], uid[1], uid[2], uid[3], uid[4], uid[5], uid[6], uid[7], addr, db_n, db_size];
-        let header_len = data.len() as u8;
         let mut num_bytes = 3;
-        let mut cmd_op = 1;
+        let mut cmd_op;
         let mut act_cnt8 = 0;
         let mut is_actuators = false;
+        let mut mem_blk1 = vec![0,0];
+        let mut mem_blk2:Vec<u8> = vec![];
+        let mut mem_blk3:Vec<u8> = vec![];
+
         let command;
         if op_mode_block.is_some(){
             let bl = op_mode_block.as_ref().unwrap();
             log::debug!("Num act blks: {:#?}, cmd_op: {:#?}, command: {:#?} ",bl.act_cnt8,bl.cmd_op,bl.command);
             command = bl.command;
+            cmd_op = bl.cmd_op;
             if command != 0 {
                 //Not all off command
-                if actuator_mode_blocks.is_some() {
-                    let mut last_int = 0;
+                if actuator_mode_blocks.is_some() && cmd_op != 0 {
                     let bl = actuator_mode_blocks.as_ref().unwrap();
                     let mut blks = vec![];
-                    if bl.block0_31.is_some(){ blks.extend([bl.block0_31.as_ref().unwrap().b0, bl.block0_31.as_ref().unwrap().b1, bl.block0_31.as_ref().unwrap().b2, bl.block0_31.as_ref().unwrap().b3].iter().copied());}
-                    if bl.block32_63.is_some(){ blks.extend([bl.block32_63.as_ref().unwrap().b3,bl.block32_63.as_ref().unwrap().b2,bl.block32_63.as_ref().unwrap().b1,bl.block32_63.as_ref().unwrap().b0].iter().copied());}
-                    if bl.block64_95.is_some(){ blks.extend([bl.block64_95.as_ref().unwrap().b3,bl.block64_95.as_ref().unwrap().b2,bl.block64_95.as_ref().unwrap().b1,bl.block64_95.as_ref().unwrap().b0].iter().copied());}
-                    if bl.block96_127.is_some(){ blks.extend([bl.block96_127.as_ref().unwrap().b3,bl.block96_127.as_ref().unwrap().b2,bl.block96_127.as_ref().unwrap().b1,bl.block96_127.as_ref().unwrap().b0].iter().copied());}
+                    if bl.block0_31.is_some(){ 
+                        mem_blk1.append(&mut vec![0,bl.block0_31.as_ref().unwrap().b0]); 
+                        blks.extend([bl.block0_31.as_ref().unwrap().b1, bl.block0_31.as_ref().unwrap().b2, bl.block0_31.as_ref().unwrap().b3].iter().copied());
+                    }
+                    if bl.block32_63.is_some(){ blks.extend([bl.block32_63.as_ref().unwrap().b0, bl.block32_63.as_ref().unwrap().b1, bl.block32_63.as_ref().unwrap().b2, bl.block32_63.as_ref().unwrap().b3].iter().copied());}
+                    if bl.block64_95.is_some(){ blks.extend([bl.block64_95.as_ref().unwrap().b0, bl.block64_95.as_ref().unwrap().b1, bl.block64_95.as_ref().unwrap().b2, bl.block64_95.as_ref().unwrap().b3].iter().copied());}
+                    if bl.block96_127.is_some(){ blks.extend([bl.block96_127.as_ref().unwrap().b0, bl.block96_127.as_ref().unwrap().b1, bl.block96_127.as_ref().unwrap().b2, bl.block96_127.as_ref().unwrap().b3].iter().copied());}
                     if blks.len() != 0 {
                         is_actuators = true;
-                        for blk in blks.into_iter() {
-                            data.push(blk);
-                            if blk != 0 { last_int = data.len(); }
+                        let mut last_int = 0;
+                        let mut cnt = 0;
+                        for blk in blks.iter_mut() { //find last relavant byte
+                            cnt += 1;
+                            if *blk != 0 { last_int = cnt; }
                         }
-                        data.truncate(last_int);
-                        act_cnt8 = (data.len() as u8) - header_len;
+                        blks.truncate(last_int); //remove unneeded bytes (trailing zeros)
+                        for chunk in blks.chunks(db_size as usize) { //populate other memory blocks if possible
+                            if mem_blk2.len() == 0 {mem_blk2.extend(chunk)}
+                            else if mem_blk3.len() == 0 {mem_blk3.extend(chunk)}
+                        }
+                        act_cnt8 = 1 + blks.len() as u8;
                         cmd_op = 2; //Command without timing config. Overwritten if timing is added.
+                    } else {
+                        act_cnt8 = 0;
                     }
                 }
                 if timer_mode_blocks.is_some() {
@@ -452,20 +466,41 @@ impl<'a> HapticV0Protocol<'a> {
                     if blks.len() != 0 {
                         if is_actuators { 
                             cmd_op = 3; //Actuator command with timing config
-                        } else {
-                            cmd_op = 0; //Only update timing
-                        }
-                        for blk in blks.into_iter() {
-                            data.push(blk);
+                            //Fill memory blocks with space
+                            while mem_blk2.len() < 4 { 
+                                mem_blk2.push(blks.remove(0));
+                            }
+                            while mem_blk3.len() < 4 {
+                                mem_blk3.push(blks.remove(0));
+                            }
+                        } else { //Only setting timing blocks
+                            for _ in 0..2 { mem_blk1.push(blks.remove(0)); } //push first two bytes into mem_blk1
+                            for chunk in blks.chunks(db_size as usize) { //populate other memory blocks if possible
+                                if mem_blk2.len() == 0 {
+                                    mem_blk2.extend(chunk)
+                                } else if mem_blk3.len() == 0 {
+                                    mem_blk3.extend(chunk)
+                                }
+                            }
                         }
                     }
-                }
-                data.push(command);
+                }                        
+                
                 let op_mode = cmd_op << 5 | act_cnt8;
-                data.push(op_mode);
-                num_bytes = (data.len() as u8) - (header_len-1); //minus 1 so num_bytes byte is counted
-                data.push(num_bytes);
-                data[11] = (((data.len() as f32 - header_len as f32)/4f32).ceil()) as u8; //calcuate number of memeory blocks to write to
+                mem_blk1[1] = op_mode;
+
+                if is_actuators {mem_blk1[2] = command;} //command not used when only setting timing
+
+                num_bytes = mem_blk1.len()+mem_blk2.len()+mem_blk3.len();
+                mem_blk1[0] = num_bytes as u8;
+                data[11] = ((num_bytes as f32/4f32).ceil()) as u8; //calcuate number of memeory blocks to write to
+                
+                mem_blk1.reverse();
+                mem_blk2.reverse();
+                mem_blk3.reverse();
+                data.extend_from_slice(mem_blk1.as_slice());
+                data.extend_from_slice(mem_blk2.as_slice());
+                data.extend_from_slice(mem_blk3.as_slice());
             } else {
                 //all off
                 act_cnt8 = bl.act_cnt8;
@@ -474,8 +509,8 @@ impl<'a> HapticV0Protocol<'a> {
                 data.push(0x00); //first byte is empty when cmd_op is 1
                 data.push(command);
                 data.push(op_mode);
-                data.push(num_bytes); //num_bytes
-            }
+                data.push(num_bytes as u8); //num_bytes
+            }    
         }   
         match self.custom_command(control_byte, data.as_slice(), true) {
             Ok(_) => { },

--- a/src/protocol/mock.rs
+++ b/src/protocol/mock.rs
@@ -16,58 +16,115 @@ impl Protocol<'_> for MockProtocol {
             CommandMessage::ActuatorsCommand { fabric_name, timer_mode_blocks, actuator_mode_blocks, op_mode_block, use_cache } => {
                 let _cache = use_cache;
                 log::trace!("Received ActuatorsCommand: {:#?} {:#?} {:#?} {:#?}", fabric_name, timer_mode_blocks, actuator_mode_blocks, op_mode_block);
-                let mut data: smallvec::SmallVec<[u8; 32]> = smallvec::smallvec![0x24,0x01,0,1,2,3,4,5,6,7];
+                let command_id = 0x24;   // Command Id for Control Byte to write blocks to transponder's RF blocks
+                let mode = 0x01; // addressed
+                let db_n = 0x01;
+                let db_size = 0x04;
+                let addr = 0x00;
+                
+                let mut data: smallvec::SmallVec<[u8; 32]> = smallvec::smallvec![command_id, mode, 0, 1, 2, 3, 4, 5, 6, 7, addr, db_n, db_size];
                 let mut num_bytes = 3;
-                let mut cmd_op = 1;
+                let mut cmd_op;
+                let mut act_cnt8 = 5;
                 let mut is_actuators = false;
+                let mut mem_blk1 = vec![0,0];
+                let mut mem_blk2:Vec<u8> = vec![];
+                let mut mem_blk3:Vec<u8> = vec![];
+
+                let command;
                 if op_mode_block.is_some(){
                     let bl = op_mode_block.as_ref().unwrap();
                     log::debug!("Num act blks: {:#?}, cmd_op: {:#?}, command: {:#?} ",bl.act_cnt8,bl.cmd_op,bl.command);
-                    if bl.command != 0 {
-                        //Not all off
-                        if actuator_mode_blocks.is_some() {
-                            is_actuators = true;
+                    command = bl.command;
+                    cmd_op = bl.cmd_op;
+                    if command != 0 {
+                        //Not all off command
+                        if actuator_mode_blocks.is_some() && cmd_op != 0 {
                             let mut last_int = 0;
                             let bl = actuator_mode_blocks.as_ref().unwrap();
-                            let blks = vec![bl.block0_31.as_ref().unwrap().b0, bl.block0_31.as_ref().unwrap().b1, bl.block0_31.as_ref().unwrap().b2, bl.block0_31.as_ref().unwrap().b3,
-                                                    bl.block32_63.as_ref().unwrap().b0,bl.block32_63.as_ref().unwrap().b1,bl.block32_63.as_ref().unwrap().b2,bl.block32_63.as_ref().unwrap().b3,
-                                                    bl.block64_95.as_ref().unwrap().b0,bl.block64_95.as_ref().unwrap().b1,bl.block64_95.as_ref().unwrap().b2,bl.block64_95.as_ref().unwrap().b3,
-                                                    bl.block96_127.as_ref().unwrap().b0,bl.block96_127.as_ref().unwrap().b1,bl.block96_127.as_ref().unwrap().b2,bl.block96_127.as_ref().unwrap().b3];
-                            for blk in blks.into_iter() {
-                                data.push(blk);
-                                if blk != 0 { last_int = data.len(); }
+                            let mut blks = vec![];
+                            if bl.block0_31.is_some(){ 
+                                mem_blk1.append(&mut vec![0,bl.block0_31.as_ref().unwrap().b0]); 
+                                blks.extend([bl.block0_31.as_ref().unwrap().b1, bl.block0_31.as_ref().unwrap().b2, bl.block0_31.as_ref().unwrap().b3].iter().copied());
                             }
-                            data.truncate(last_int);
-                            cmd_op = 2; //Command without timing config. Overwritten if timing is added.
+                            if bl.block32_63.is_some(){ blks.extend([bl.block32_63.as_ref().unwrap().b0, bl.block32_63.as_ref().unwrap().b1, bl.block32_63.as_ref().unwrap().b2, bl.block32_63.as_ref().unwrap().b3].iter().copied());}
+                            if bl.block64_95.is_some(){ blks.extend([bl.block64_95.as_ref().unwrap().b0, bl.block64_95.as_ref().unwrap().b1, bl.block64_95.as_ref().unwrap().b2, bl.block64_95.as_ref().unwrap().b3].iter().copied());}
+                            if bl.block96_127.is_some(){ blks.extend([bl.block96_127.as_ref().unwrap().b0, bl.block96_127.as_ref().unwrap().b1, bl.block96_127.as_ref().unwrap().b2, bl.block96_127.as_ref().unwrap().b3].iter().copied());}
+                            if blks.len() != 0 {
+                                is_actuators = true;
+                                let mut cnt = 0;
+                                for blk in blks.iter_mut() { //find last relavant byte
+                                    cnt += 1;
+                                    if *blk != 0 { last_int = cnt; }
+                                }
+                                blks.truncate(last_int); //remove unneeded bytes (trailing zeros)
+                                for chunk in blks.chunks(db_size as usize) { //populate other memory blocks if possible
+                                    if mem_blk2.len() == 0 {mem_blk2.extend(chunk)}
+                                    else if mem_blk3.len() == 0 {mem_blk3.extend(chunk)}
+                                }
+                                act_cnt8 = 1 + blks.len() as u8;
+                                cmd_op = 2; //Command without timing config. Overwritten if timing is added.
+                            } else {
+                                act_cnt8 = 0;
+                            }
                         }
                         if timer_mode_blocks.is_some() {
-                            if is_actuators { 
-                                cmd_op = 3; //Actuator command with timing config
-                            } else {
-                                cmd_op = 0; //Only update timing
-                            }
                             let bl = timer_mode_blocks.as_ref().unwrap();
-                            let blks = vec![bl.single_pulse_block.as_ref().unwrap().b0,bl.single_pulse_block.as_ref().unwrap().b1,bl.single_pulse_block.as_ref().unwrap().b2,
-                                                    bl.hf_block.as_ref().unwrap().b0,bl.hf_block.as_ref().unwrap().b1,bl.hf_block.as_ref().unwrap().b2,
-                                                    bl.lf_block.as_ref().unwrap().b0,bl.lf_block.as_ref().unwrap().b1,bl.lf_block.as_ref().unwrap().b2];
-                            for blk in blks.into_iter() {
-                                data.push(blk);
+                            let mut blks = vec![];
+                            if bl.single_pulse_block.is_some() {blks.extend([bl.single_pulse_block.as_ref().unwrap().b0,bl.single_pulse_block.as_ref().unwrap().b1,bl.single_pulse_block.as_ref().unwrap().b2].iter().copied());}
+                            if bl.hf_block.is_some() {blks.extend([bl.hf_block.as_ref().unwrap().b0,bl.hf_block.as_ref().unwrap().b1,bl.hf_block.as_ref().unwrap().b2].iter().copied());}
+                            if bl.lf_block.is_some() {blks.extend([bl.lf_block.as_ref().unwrap().b0,bl.lf_block.as_ref().unwrap().b1,bl.lf_block.as_ref().unwrap().b2].iter().copied());}
+                            if blks.len() != 0 {
+                                if is_actuators { 
+                                    cmd_op = 3; //Actuator command with timing config
+                                    //Fill memory blocks with space
+                                    while mem_blk2.len() < 4 { 
+                                        mem_blk2.push(blks.remove(0));
+                                    }
+                                    while mem_blk3.len() < 4 {
+                                        mem_blk3.push(blks.remove(0));
+                                    }
+                                } else {
+                                    for _ in 0..2 { mem_blk1.push(blks.remove(0)); } //push first two bytes into mem_blk1
+                                    for chunk in blks.chunks(db_size as usize) { //populate other memory blocks if possible
+                                        if mem_blk2.len() == 0 {
+                                            mem_blk2.extend(chunk)
+                                        } else if mem_blk3.len() == 0 {
+                                            mem_blk3.extend(chunk)
+                                        }
+                                    }
+                                    
+                                }
                             }
-                        }
-                        let op_mode = cmd_op << 5 | bl.act_cnt8;
-                        data.insert(10, op_mode);
-                        num_bytes = (data.len() as u8) - 9;
-                        data.insert(10, num_bytes);
+                        }                        
+                        
+                        let op_mode = cmd_op << 5 | act_cnt8;
+                        mem_blk1[1] = op_mode;
+
+                        if is_actuators {mem_blk1[2] = command;} //command not used when only setting timing
+
+                        num_bytes = mem_blk1.len()+mem_blk2.len()+mem_blk3.len();
+                        mem_blk1[0] = num_bytes as u8;
+                        data[11] = ((num_bytes as f32/4f32).ceil()) as u8; //calcuate number of memeory blocks to write to
+                        
+                        mem_blk1.reverse();
+                        mem_blk2.reverse();
+                        mem_blk3.reverse();
+                        data.extend_from_slice(mem_blk1.as_slice());
+                        data.extend_from_slice(mem_blk2.as_slice());
+                        data.extend_from_slice(mem_blk3.as_slice());
                     } else {
                         //all off
-                        let op_mode = bl.act_cnt8;
-                        data.push(num_bytes); //num_bytes
+                        act_cnt8 = bl.act_cnt8;
+                        let op_mode = cmd_op << 5 | act_cnt8;
+                        // LSB first
+                        data.push(0x00); //first byte is empty when cmd_op is 1
+                        data.push(command);
                         data.push(op_mode);
-                        data.push(bl.command);
+                        data.push(num_bytes as u8); //num_bytes
                     }
-                    log::debug!("Sending command: {:#?}", hex::encode(data));
-                }   
-                
+                }
+                log::debug!("Send command: {:#?}", hex::encode(data));
                 Ok(())
             },
             _ => {

--- a/src/protocol/mock.rs
+++ b/src/protocol/mock.rs
@@ -12,6 +12,69 @@ impl MockProtocol {
 
 impl Protocol<'_> for MockProtocol {
     fn handle_message(self: &mut Self, _message: &CommandMessage) -> Result<()> {
-        Ok(())
+        match _message {
+            CommandMessage::ActuatorsCommand { fabric_name, timer_mode_blocks, actuator_mode_blocks, op_mode_block, use_cache } => {
+                let _cache = use_cache;
+                log::trace!("Received ActuatorsCommand: {:#?} {:#?} {:#?} {:#?}", fabric_name, timer_mode_blocks, actuator_mode_blocks, op_mode_block);
+                let mut data: smallvec::SmallVec<[u8; 32]> = smallvec::smallvec![0x24,0x01,0,1,2,3,4,5,6,7];
+                let mut num_bytes = 3;
+                let mut cmd_op = 1;
+                let mut is_actuators = false;
+                if op_mode_block.is_some(){
+                    let bl = op_mode_block.as_ref().unwrap();
+                    log::debug!("Num act blks: {:#?}, cmd_op: {:#?}, command: {:#?} ",bl.act_cnt8,bl.cmd_op,bl.command);
+                    if bl.command != 0 {
+                        //Not all off
+                        if actuator_mode_blocks.is_some() {
+                            is_actuators = true;
+                            let mut last_int = 0;
+                            let bl = actuator_mode_blocks.as_ref().unwrap();
+                            let blks = vec![bl.block0_31.as_ref().unwrap().b0, bl.block0_31.as_ref().unwrap().b1, bl.block0_31.as_ref().unwrap().b2, bl.block0_31.as_ref().unwrap().b3,
+                                                    bl.block32_63.as_ref().unwrap().b0,bl.block32_63.as_ref().unwrap().b1,bl.block32_63.as_ref().unwrap().b2,bl.block32_63.as_ref().unwrap().b3,
+                                                    bl.block64_95.as_ref().unwrap().b0,bl.block64_95.as_ref().unwrap().b1,bl.block64_95.as_ref().unwrap().b2,bl.block64_95.as_ref().unwrap().b3,
+                                                    bl.block96_127.as_ref().unwrap().b0,bl.block96_127.as_ref().unwrap().b1,bl.block96_127.as_ref().unwrap().b2,bl.block96_127.as_ref().unwrap().b3];
+                            for blk in blks.into_iter() {
+                                data.push(blk);
+                                if blk != 0 { last_int = data.len(); }
+                            }
+                            data.truncate(last_int);
+                            cmd_op = 2; //Command without timing config. Overwritten if timing is added.
+                        }
+                        if timer_mode_blocks.is_some() {
+                            if is_actuators { 
+                                cmd_op = 3; //Actuator command with timing config
+                            } else {
+                                cmd_op = 0; //Only update timing
+                            }
+                            let bl = timer_mode_blocks.as_ref().unwrap();
+                            let blks = vec![bl.single_pulse_block.as_ref().unwrap().b0,bl.single_pulse_block.as_ref().unwrap().b1,bl.single_pulse_block.as_ref().unwrap().b2,
+                                                    bl.hf_block.as_ref().unwrap().b0,bl.hf_block.as_ref().unwrap().b1,bl.hf_block.as_ref().unwrap().b2,
+                                                    bl.lf_block.as_ref().unwrap().b0,bl.lf_block.as_ref().unwrap().b1,bl.lf_block.as_ref().unwrap().b2];
+                            for blk in blks.into_iter() {
+                                data.push(blk);
+                            }
+                        }
+                        let op_mode = cmd_op << 5 | bl.act_cnt8;
+                        data.insert(10, op_mode);
+                        num_bytes = (data.len() as u8) - 9;
+                        data.insert(10, num_bytes);
+                    } else {
+                        //all off
+                        let op_mode = bl.act_cnt8;
+                        data.push(num_bytes); //num_bytes
+                        data.push(op_mode);
+                        data.push(bl.command);
+                    }
+                    log::debug!("Sending command: {:#?}", hex::encode(data));
+                }   
+                
+                Ok(())
+            },
+            _ => {
+                log::debug!("Mock ignoring: {:?}", _message);
+                Ok(())
+            }
+        }
+
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -73,9 +73,9 @@ fn e2e_pulsing_after_antenna_reset() -> Result<()> {
 fn e2e_pulsing() -> Result<()> {
     // Issues commands to enable all actuators in the single fabric of 36 in continuous 50 ms on 50 ms off
     let op_mode_block = protocol_host_lib::protocol::haptic::v0::OpModeBlock {
-        act_cnt32: 0x02, // ceil(36.0 / 32.0) = 2
-        act_mode: 0x00,
-        op_mode: 0x02,
+        act_cnt8: 0x02, // ceil(36.0 / 32.0) = 2
+        cmd_op: 0x00,
+        command: 0x02,
     };
     let op_mode_block = serde_json::to_string(&op_mode_block)?;
 
@@ -120,7 +120,6 @@ fn e2e_pulsing() -> Result<()> {
             b0: 0x00,
             b1: 0x00,
             b2: 0x00,
-            b3: 0x00,
         }),
 
         /*
@@ -133,7 +132,6 @@ fn e2e_pulsing() -> Result<()> {
             b0: ((hf_duty_cycle & 0x00FF)) as u8,
             b1: ((hf_duty_cycle & 0xFF00) >> 8) as u8,
             b2: ((hf_period & 0x00FF)) as u8,
-            b3: ((hf_period & 0xFF00) >> 8) as u8,
         }),
 
         /*
@@ -146,7 +144,6 @@ fn e2e_pulsing() -> Result<()> {
             b0: 0xFF, // ((4000 & 0x00FF)) as u8,
             b1: 0xFF, // ((4000 & 0xFF00) >> 8) as u8,
             b2: 0xFF, // ((4000 & 0x00FF)) as u8,
-            b3: 0xFF, // ((4000 & 0xFF00) >> 8) as u8,
         })
     };
     let timer_mode_blocks= serde_json::to_string(&timer_mode_blocks)?;
@@ -167,9 +164,9 @@ fn e2e_pulsing() -> Result<()> {
 fn send_all_off() -> Result<()> {
     // Issues commands to enable all actuators in the single fabric of 36 in continuous 50 ms on 50 ms off
     let op_mode_block = protocol_host_lib::protocol::haptic::v0::OpModeBlock {
-        act_cnt32: 0x02, // ceil(36.0 / 32.0) = 2
-        act_mode: 0x00,
-        op_mode: 0x00,
+        act_cnt8: 0x02, // ceil(36.0 / 32.0) = 2
+        cmd_op: 0x00,
+        command: 0x00,
     };
     let op_mode_block = serde_json::to_string(&op_mode_block)?;
 
@@ -214,7 +211,6 @@ fn send_all_off() -> Result<()> {
             b0: 0x00,
             b1: 0x00,
             b2: 0x00,
-            b3: 0x00,
         }),
 
         /*
@@ -227,7 +223,6 @@ fn send_all_off() -> Result<()> {
             b0: ((hf_duty_cycle & 0x00FF)) as u8,
             b1: ((hf_duty_cycle & 0xFF00) >> 8) as u8,
             b2: ((hf_period & 0x00FF)) as u8,
-            b3: ((hf_period & 0xFF00) >> 8) as u8,
         }),
 
         /*
@@ -240,7 +235,6 @@ fn send_all_off() -> Result<()> {
             b0: 0xFF, // ((4000 & 0x00FF)) as u8,
             b1: 0xFF, // ((4000 & 0xFF00) >> 8) as u8,
             b2: 0xFF, // ((4000 & 0x00FF)) as u8,
-            b3: 0xFF, // ((4000 & 0xFF00) >> 8) as u8,
         })
     };
     let timer_mode_blocks= serde_json::to_string(&timer_mode_blocks)?;


### PR DESCRIPTION
New firmware version has a different format for building commands.
The actuators_command function in the hapticv0 protocol was updated to match the new firmware version.

Changes include: 
- op_mode renamed to command: still sets alloff, single pulse, continuous,...
- op_mode now is the combination of cmd_op and number of actuators in sets of 8.
- num_bytes is the number of bytes in the command, including itself.
- Timing blocks only have 6 bytes instead of 8.
- Added actuator command building to mock protocol for testing purposes only.

Misc. typo and spacing fixes.